### PR TITLE
Drop junction

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,3 +62,14 @@ mway.start('init')
 ```
 
 And thats it! Motorway will now run your junctions and actions in order.
+
+## Testing your apps
+
+Assuming that your Motorway ends in a junction called `launch` which has the action to host your application you would not want it to do this when testing, to help with this you can drop junctions to skip them. For example:
+
+```javascript
+mway.dropJunction('launch')
+mway.start('init')
+```
+
+You will now get your full application loaded but not hosted, perfect for running tests

--- a/src/motorway.coffee
+++ b/src/motorway.coffee
@@ -28,6 +28,12 @@ module.exports =
       else
         @actions.add({junction: junction, func: func})
 
+    dropJunction: (name) ->
+      junction = @junctions.findOne({name: name})
+      junction.complete = true
+      junction.runAfter = []
+      @junctions.update(junction)
+
     start: (junction) ->
       runner = new Runner(@junctions.findOne({name: junction}), @actions.where({junction: junction}), @emitter)
       runner.start()

--- a/tests/motorway-tests.coffee
+++ b/tests/motorway-tests.coffee
@@ -132,3 +132,28 @@ describe 'Motorway', ->
       done()
 
     mway.start('init')
+
+  it 'should let you drop junctions', (done) ->
+    mway = new Motorway()
+
+    passed = false
+
+    mway.addJunction('pass')
+    mway.addJunction('fail', ['pass'])
+    mway.addJunction('test', ['pass', 'fail'])
+
+    mway.addAction 'pass', ->
+      passed = true
+      @rejoin()
+
+    mway.addAction 'fail', ->
+      passed = false
+      @rejoin()
+
+    mway.addAction 'test', ->
+      expect(passed).to.eq true
+      done()
+
+    mway.dropJunction('fail')
+
+    mway.start('pass')


### PR DESCRIPTION
Allow for the dropping of junctions.

This would be so you can test your apps by dropping the _run_ junction
