### PR TITLE
Allow junctions to be loaded from files

### DIFF
--- a/src/motorway.coffee
+++ b/src/motorway.coffee
@@ -18,6 +18,14 @@ module.exports =
 
       return this
 
+    loadJunction: (modulePath) ->
+      junction = require modulePath
+
+      @addJunction junction.name, junction.runAfter
+
+      for action in junction.actions
+        @addAction junction.name, action
+
     addJunction: (name, runAfter = []) ->
       @junctions.add({name: name, runAfter: runAfter, started: 0, run: 0, complete: false})
 

--- a/support/junction.coffee
+++ b/support/junction.coffee
@@ -1,0 +1,7 @@
+module.exports =
+  name: 'configure'
+  runAfter: ['init']
+  actions: [
+    ->
+      @rejoin()
+  ]

--- a/tests/motorway-tests.coffee
+++ b/tests/motorway-tests.coffee
@@ -157,3 +157,18 @@ describe 'Motorway', ->
     mway.dropJunction('fail')
 
     mway.start('pass')
+
+  it 'should load a junction from a file', (done) ->
+    mway = new Motorway()
+
+    mway.addJunction 'init'
+    mway.loadJunction '../support/junction.coffee'
+    mway.addJunction 'finish', ['configure']
+
+    mway.addAction 'init', ->
+      @rejoin()
+
+    mway.addAction 'finish', ->
+      done()
+
+    mway.start 'init'


### PR DESCRIPTION
As the title suggests adds Motorway.loadJunction to allow you to load junctions from a file
